### PR TITLE
Fix the operator precedence within JPA query_spec.

### DIFF
--- a/lib/domgen/jpa/model.rb
+++ b/lib/domgen/jpa/model.rb
@@ -151,7 +151,7 @@ module Domgen
       end
 
       def query_spec
-        @query_spec || (ql =~ /\sFROM\s/ix) ? :statement : :criteria
+        @query_spec || ((ql =~ /\sFROM\s/ix) ? :statement : :criteria)
       end
 
       def multiplicity


### PR DESCRIPTION
The Domgen::JPA::Query#query_spec method currently ignores explicit
requests for query_spec = :criteria, this change makes it obey settings
provided by the user.
