### PR TITLE
Add configuration for sql.sql_driver

### DIFF
--- a/lib/domgen/jpa/templates/abstract_entity_test.java.erb
+++ b/lib/domgen/jpa/templates/abstract_entity_test.java.erb
@@ -16,7 +16,9 @@ public abstract class <%= repository.jpa.abstract_entity_test_name %>
   public void preTest()
     throws Exception
   {
+    System.setProperty( "test.db.driver", "<%= repository.facet(:sql).sql_driver %>" );
     super.preTest();
+
     final <%= repository.jpa.qualified_test_factory_set_name %> factorySet = new <%= repository.jpa.qualified_test_factory_set_name %>( getInjector() );
 <% repository.data_modules.select{|data_module| data_module.jpa?}.each do |data_module| -%>
     <%= data_module.jpa.short_test_code %> = factorySet.<%= Domgen::Naming.camelize(data_module.name) %>();

--- a/lib/domgen/jpa/templates/abstract_entity_test.java.erb
+++ b/lib/domgen/jpa/templates/abstract_entity_test.java.erb
@@ -16,7 +16,7 @@ public abstract class <%= repository.jpa.abstract_entity_test_name %>
   public void preTest()
     throws Exception
   {
-    System.setProperty( "test.db.driver", "<%= repository.facet(:sql).sql_driver %>" );
+    System.setProperty( "test.db.driver", "<%= repository.sql.sql_driver %>" );
     super.preTest();
 
     final <%= repository.jpa.qualified_test_factory_set_name %> factorySet = new <%= repository.jpa.qualified_test_factory_set_name %>( getInjector() );

--- a/lib/domgen/sql/model.rb
+++ b/lib/domgen/sql/model.rb
@@ -385,6 +385,22 @@ module Domgen
           end
         end
       end
+
+      attr_writer :sql_driver
+
+      def sql_driver
+        if @sql_driver.nil?
+          @sql_driver =
+            if self.repository.facet_enabled?(:pgsql)
+              "org.postgresql.Driver"
+            elsif self.repository.facet_enabled?(:mssql)
+              "net.sourceforge.jtds.jdbc.Driver"
+            else
+              raise 'No default SQL driver available, specify one with repository.sql.sql_driver = "your.driver.here"'
+            end
+        end
+        @sql_driver
+      end
     end
 
     facet.enhance(DataModule) do

--- a/lib/domgen/sql/model.rb
+++ b/lib/domgen/sql/model.rb
@@ -391,10 +391,10 @@ module Domgen
       def sql_driver
         if @sql_driver.nil?
           @sql_driver =
-            if self.repository.facet_enabled?(:pgsql)
-              "org.postgresql.Driver"
-            elsif self.repository.facet_enabled?(:mssql)
-              "net.sourceforge.jtds.jdbc.Driver"
+            if self.repository.pgsql?
+              'org.postgresql.Driver'
+            elsif self.repository.mssql?
+              'net.sourceforge.jtds.jdbc.Driver'
             else
               raise 'No default SQL driver available, specify one with repository.sql.sql_driver = "your.driver.here"'
             end


### PR DESCRIPTION
Use sql_driver to set jdbc driver class in abstract entity test