### PR TITLE
Generate constraints that don't fail when column contains null.

### DIFF
--- a/lib/domgen/pgsql/model.rb
+++ b/lib/domgen/pgsql/model.rb
@@ -81,16 +81,16 @@ module Domgen
       def post_verify_table_customization(table)
         table.entity.attributes.select { |a| a.sql? && a.geometry? }.each do |a|
           constraint_name = "#{a.name}_ValidGeometry"
-          table.constraint(constraint_name, :sql => "ST_IsValid(#{quote(a.sql.column_name)})") unless table.constraint_by_name(constraint_name)
+          table.constraint(constraint_name, :sql => "#{quote(a.sql.column_name)} IS NULL OR ST_IsValid(#{quote(a.sql.column_name)})") unless table.constraint_by_name(constraint_name)
 
           if a.geometry.geometry_type == :geometry
             if a.geometry.dimensions
               constraint_name = "#{a.name}_ValidDimensions"
-              table.constraint(constraint_name, :sql => "ST_ndims(#{quote(a.sql.column_name)}) = #{a.geometry.dimensions}") unless table.constraint_by_name(constraint_name)
+              table.constraint(constraint_name, :sql => "#{quote(a.sql.column_name)} IS NULL OR ST_ndims(#{quote(a.sql.column_name)}) = #{a.geometry.dimensions}") unless table.constraint_by_name(constraint_name)
             end
             if a.geometry.srid
               constraint_name = "#{a.name}_ValidSpatialReferenceID"
-              table.constraint(constraint_name, :sql => "ST_srid(#{quote(a.sql.column_name)}) = #{a.geometry.srid}") unless table.constraint_by_name(constraint_name)
+              table.constraint(constraint_name, :sql => "#{quote(a.sql.column_name)} IS NULL OR ST_srid(#{quote(a.sql.column_name)}) = #{a.geometry.srid}") unless table.constraint_by_name(constraint_name)
             end
           end
         end


### PR DESCRIPTION
I'd prefer to be doing this only if the column is also nullable, but didn't see an easy way to do that.  Nullable column attribute should take care of it anyway.