### PR TITLE
Register interface names rather than implementations with jaxrs.

### DIFF
--- a/lib/domgen/jaxrs/templates/abstract_application.java.erb
+++ b/lib/domgen/jaxrs/templates/abstract_application.java.erb
@@ -12,8 +12,8 @@ public abstract class <%= repository.jaxrs.abstract_application_name %>
   public java.util.Set<Class<?>> getClasses()
   {
     final java.util.Set<Class<?>> classes = new java.util.HashSet<Class<?>>();
-<% repository.data_modules.select{|d| d.jaxrs?}.collect {|d| d.services.select{|s| s.jaxrs?}.collect {|s| s.jaxrs.qualified_boundary_name }}.flatten.each do |boundary_name| -%>
-    classes.add( <%= boundary_name %>.class );
+<% repository.data_modules.select{|d| d.jaxrs?}.collect {|d| d.services.select{|s| s.jaxrs?}.collect {|s| s.jaxrs.qualified_service_name }}.flatten.each do |service_name| -%>
+    classes.add( <%= service_name %>.class );
 <% end -%>
     return classes;
   }


### PR DESCRIPTION
Aligns with the Singleton Name on the Impl annotation.
Fixes inability to resolve the Impl at runtime.