### PR TITLE
Marshalling test to work with Real parameters on structs.

### DIFF
--- a/lib/domgen/jackson/templates/marshalling_test.java.erb
+++ b/lib/domgen/jackson/templates/marshalling_test.java.erb
@@ -28,6 +28,8 @@ def create_parameter_value(p, parent_context = nil)
   v =
     if p.integer?
       "1"
+    elsif p.real?
+      "1.1F"
     elsif p.reference?
       create_parameter_value(p.referenced_entity.primary_key)
     elsif p.boolean?

--- a/lib/domgen/jaxb/templates/marshalling_test.java.erb
+++ b/lib/domgen/jaxb/templates/marshalling_test.java.erb
@@ -34,6 +34,8 @@ def create_parameter_value(p, parent_context = nil)
   v =
     if p.integer?
       "1"
+    elsif p.real?
+      "1.1F"
     elsif p.reference?
       create_parameter_value(p.referenced_entity.primary_key)
     elsif p.boolean?


### PR DESCRIPTION
Domgen was failing to generate because we had a real parameter in our struct:
```
    data_module.struct(:RefuelVO) do |t|
      t.integer(:ID, :nullable => true)
      t.integer(:ServerID, :nullable => true)
      t.datetime(:OccurredAt, :nullable => true)
      t.real(:Amount, :nullable => true)
      t.text(:Pilot, :nullable => true)
      t.real(:FuelRemaining, :nullable => true)
      t.struct(:Aircraft, :AircraftVO, :nullable => true)
    end
```