### PR TITLE
Correctly detect methods requiring cookies

### DIFF
--- a/lib/domgen/gwt_rpc/templates/servlet.java.erb
+++ b/lib/domgen/gwt_rpc/templates/servlet.java.erb
@@ -234,9 +234,8 @@ end.join(', ') %>);
   }
 <% end %>
 <%
-has_cookie = false
- service.methods.select{|method| method.gwt_rpc?}.each do |method|
-   has_cookie = method.parameters.any?{|p| p.gwt_rpc.environmental? && p.gwt_rpc.environment_key_is_cookie?}
+has_cookie = service.methods.select{|method| method.gwt_rpc?}.any? do |method|
+   method.parameters.any?{|p| p.gwt_rpc.environmental? && p.gwt_rpc.environment_key_is_cookie?}
  end
 if has_cookie
 %>


### PR DESCRIPTION
Previously only successfully detected if the last method for a service required a cookie.