### PR TITLE
Don't add ejb specific annotations to Exceptions

### DIFF
--- a/lib/domgen/ee/templates/exception.java.erb
+++ b/lib/domgen/ee/templates/exception.java.erb
@@ -4,7 +4,6 @@ package <%= to_package(exception.ee.qualified_name) %>;
 @javax.annotation.Generated( "Domgen" )
 @edu.umd.cs.findbugs.annotations.SuppressFBWarnings({"EI_EXPOSE_REP", "EI_EXPOSE_REP2", "DLS_DEAD_LOCAL_STORE"})
 @java.lang.SuppressWarnings( { "UnusedDeclaration", "JavaDoc" } )
-@javax.ejb.ApplicationException( rollback = <%= exception.ejb.rollback? %>, inherited = true )
 public class <%= exception.ee.name %> extends <%= exception.extends.nil? ? exception.java.standard_extends : exception.data_module.exception_by_name(exception.extends).ee.qualified_name %>
 {
 <% exception.declared_parameters.each do |parameter| %>


### PR DESCRIPTION
We don't export services as EJB beans any more.