### PR TITLE
For Mssql, when generating the MappingKey use the MappingKey from rel…

### DIFF
--- a/lib/domgen/sync/templates/sync_temp_factory.java.erb
+++ b/lib/domgen/sync/templates/sync_temp_factory.java.erb
@@ -22,7 +22,7 @@ public class <%= data_module.sync.sync_temp_factory_name %>
 <% data_module.sync.entities_to_synchronize.each do |entity|
 
   sync_attributes = entity.sync.attributes_to_synchronize.collect{|a| entity.sync.sync_temp_entity.attribute_by_name(a.reference? ? "#{a.name}MappingId" : a.name) }
-  immutable_sync_attributes = entity.sync.attributes_to_synchronize.select{|a| a.immutable? }.collect{|a| entity.sync.sync_temp_entity.attribute_by_name(a.reference? ? "#{a.name}MappingId" : a.name) }
+  immutable_sync_attributes = entity.sync.attributes_to_synchronize.select{|a| a.immutable? }
 -%>
 
   public void resetIdentity<%= entity.qualified_name.gsub('.','') %>()
@@ -47,23 +47,35 @@ public class <%= data_module.sync.sync_temp_factory_name %>
       ")\n" +
       "<%= j_escape_string( "INSERT INTO #{entity.sync.sync_temp_entity.sql.qualified_table_name} (#{entity.sync.sync_temp_entity.attribute_by_name(:MappingSource).sql.quoted_column_name }, #{sync_attributes.collect{|a| a.sql.quoted_column_name }.join(', ') })") %>\n" +
       "  SELECT \n" +
-      "    <%= j_escape_string( entity.sync.sync_temp_entity.attribute_by_name(:MappingSource).sql.quoted_column_name ) %>, \n" +
+      "    CTE.<%= j_escape_string( entity.sync.sync_temp_entity.attribute_by_name(:MappingSource).sql.quoted_column_name ) %>, \n" +
 <%
   sync_attributes.each_with_index do |a, i|
  comma = i == sync_attributes.size - 1 ? '' : ','
   if immutable_sync_attributes.size > 0 && a.name == :MappingKey -%>
 <% if data_module.repository.mssql? -%>
-      "    SyncTemp.fnConvertBinaryToBase64(HASHBYTES('SHA1', <%= immutable_sync_attributes.collect{|other| "COALESCE(CONVERT(VARCHAR(50),#{j_escape_string(other.sql.quoted_column_name)}),'')"}.join(" + '.' + ") %>))<%= comma %> \n"+
+      "    SyncTemp.fnConvertBinaryToBase64(HASHBYTES('SHA1', <%= immutable_sync_attributes.collect{|other|
+  is_external_ref = other.reference? && other.referenced_entity.sync.master? && (other.referenced_entity.sync.core_entity.entity != entity)
+  col_name = other.reference? ? "#{other.name}MappingId" : other.name
+  "COALESCE(CONVERT(VARCHAR(50),#{
+        j_escape_string(is_external_ref ? "#{other.sql.column_name.to_s}Table.MappingKey" : "CTE.#{col_name}")}),'')"
+  }.join(" + '.' + \" +\n     \"      ") %>))" +
+  "<%= comma %> \n"+
 <% elsif data_module.repository.pgsql? -%>
       "    md5(<%= immutable_sync_attributes.collect{|other| "COALESCE(CAST(#{j_escape_string(other.sql.quoted_column_name)} AS VARCHAR(50)),'')"}.join(" || '.' || ") %>)<%= comma %> \n"+
 <% else -%>
 <% raise 'Unsupported database variant' -%>
 <% end -%>
 <% else -%>
-      "    <%= j_escape_string(a.sql.quoted_column_name) %><%= comma %> \n" +
+      "    CTE.<%= j_escape_string(a.sql.quoted_column_name) %><%= comma %> \n" +
 <% end -%>
 <% end -%>
-      "  FROM CTE";
+      "  FROM CTE <%=
+  if data_module.repository.mssql?
+    immutable_sync_attributes.select{|other| other.reference? && other.referenced_entity.sync.master? && (other.referenced_entity.sync.core_entity.entity != entity)}.collect{|other|
+      ref_is_transaction_time = other.referenced_entity.transaction_time?
+      "    LEFT JOIN #{other.referenced_entity.sql.qualified_table_name} #{other.sql.column_name.to_s}Table ON #{other.sql.column_name.to_s}Table.MappingId = CTE.#{
+      entity.sync.sync_temp_entity.attribute_by_name("#{other.name}MappingId").sql.quoted_column_name} #{ref_is_transaction_time ? " AND #{other.sql.column_name.to_s}Table.#{other.referenced_entity.attribute_by_name(:DeletedAt).sql.quoted_column_name} IS NULL " : ""}"}.join("\" + \n   \"")
+  end %>";
   }
 
   public int insert<%= entity.qualified_name.gsub('.','') %>BySql( @javax.annotation.Nonnull final String selectSql )


### PR DESCRIPTION
…ated entities, rather than the MappingId.

Fixes the situation where the related entity is recreated but retains its same MappingId.