### PR TITLE
2 fixes

### DIFF
--- a/lib/domgen/sync/templates/sync_context_impl.java.erb
+++ b/lib/domgen/sync/templates/sync_context_impl.java.erb
@@ -322,7 +322,7 @@ public abstract class <%= data_module.sync.sync_context_impl_name %>
     {
       _<%= Reality::Naming.camelize(entity.data_module.name) %><%= entity.name %>Repository.persist( entity );
       _entityManager.
-        createNativeQuery( "<%= j_escape_string("UPDATE #{ entity.sync.master_entity.sql.qualified_table_name } SET #{ entity.sync.master_entity.attribute_by_name( entity.root_entity.name ).sql.quoted_column_name } = ?, #{ data_module.sql.dialect.quote('MasterSynchronized') } = ? WHERE #{ data_module.sql.dialect.quote('MappingId') } = ? AND #{ data_module.sql.dialect.quote('MappingSource') } = ? AND #{ data_module.sql.dialect.quote('MasterSynchronized') } = #{entity.sql.dialect.false_sql}") %>" ).
+        createNativeQuery( "<%= j_escape_string("UPDATE #{ entity.sync.master_entity.sql.qualified_table_name } SET #{ entity.sync.master_entity.attribute_by_name( entity.root_entity.name ).sql.quoted_column_name } = ?, #{ data_module.sql.dialect.quote('MasterSynchronized') } = ? WHERE #{ data_module.sql.dialect.quote('MappingId') } = ? AND #{ data_module.sql.dialect.quote('MappingSource') } = ? AND #{ data_module.sql.dialect.quote('MasterSynchronized') } = #{entity.sql.dialect.false_sql} AND #{ entity.sync.master_entity.attribute_by_name( entity.root_entity.name ).sql.quoted_column_name } IS NULL") %>" ).
         setParameter( 1, entity.<%= getter_for(entity.primary_key) %> ).
         setParameter( 2, Boolean.TRUE ).
         setParameter( 3, v_MappingId ).
@@ -355,7 +355,7 @@ public abstract class <%= data_module.sync.sync_context_impl_name %>
 <% if entity.sync.support_remove? -%>
   @java.lang.Override
   @java.lang.SuppressWarnings( "deprecation" )
-  public boolean remove<%= entity.data_module.name %><%= entity.name %>( final int mappingId, @javax.annotation.Nullable final <%= entity.primary_key.jpa.java_type(:boundary) %> id )
+  public boolean remove<%= entity.data_module.name %><%= entity.name %>( final int masterId, @javax.annotation.Nullable final <%= entity.primary_key.jpa.java_type(:boundary) %> id )
   {
     boolean deleted = false;
     if( null != id )
@@ -408,7 +408,7 @@ public abstract class <%= data_module.sync.sync_context_impl_name %>
     _entityManager.
       createNativeQuery( "<%= j_escape_string("UPDATE #{ entity.sync.master_entity.sql.qualified_table_name } SET #{ data_module.sql.dialect.quote('MasterSynchronized') } = ? WHERE #{ data_module.sql.dialect.quote('Id') } = ?") %>" ).
       setParameter( 1, Boolean.TRUE ).
-      setParameter( 2, mappingId ).
+      setParameter( 2, masterId ).
       executeUpdate();
     return deleted;
   }

--- a/lib/domgen/sync/templates/sync_ejb.java.erb
+++ b/lib/domgen/sync/templates/sync_ejb.java.erb
@@ -324,10 +324,10 @@ public class <%= data_module.sync.sync_ejb_name %>
       errors.clear();
       for ( final Object[] result : results )
       {
-        final int mappingId = (Integer) result[ 0 ];
+        final int masterId = (Integer) result[ 0 ];
         try
         {
-          if ( _context.remove<%= entity.data_module.name %><%= entity.name %>( mappingId, ( <%= entity.primary_key.jpa.java_type(:boundary) %> ) result[ 1 ] ) )
+          if ( _context.remove<%= entity.data_module.name %><%= entity.name %>( masterId, ( <%= entity.primary_key.jpa.java_type(:boundary) %> ) result[ 1 ] ) )
           {
             recorder.incMetric( "<%= entity.data_module.name %>.<%= entity.name %>.RemoveCount", 1 );
           }
@@ -335,12 +335,12 @@ public class <%= data_module.sync.sync_ejb_name %>
         catch ( final UnsupportedOperationException e )
         {
           errors.add( result );
-          recordSyncError( recorder, 1, "Attempt to synchronize removal of <%= entity.qualified_name %> with mapping Id " + mappingId + " is not supported. Reason: " + e.getMessage() );
+          recordSyncError( recorder, 1, "Attempt to synchronize removal of <%= entity.qualified_name %> with Master Id " + masterId + " is not supported. Reason: " + e.getMessage() );
         }
         catch ( final Exception e )
         {
           errors.add( result );
-          recordSyncError( recorder, 1, "Attempt to synchronize removal of <%= entity.qualified_name %> with mapping Id " + mappingId + " generated an error.", e );
+          recordSyncError( recorder, 1, "Attempt to synchronize removal of <%= entity.qualified_name %> with Master Id " + masterId + " generated an error.", e );
         }
       }
     }


### PR DESCRIPTION
Fix attempt to alter Master records which already have a reference into Core when sync has a deletion + creation for the same mappingId.

Align variable names with usage for MasterId vs MappingId