### PR TITLE
Fixed bug when Struct has Integer Sequence field.

### DIFF
--- a/lib/domgen/gwt/templates/struct.java.erb
+++ b/lib/domgen/gwt/templates/struct.java.erb
@@ -64,6 +64,7 @@ public final class <%= struct.gwt.name %>
         when field.date? then Proc.new {|transport_value| "#{field.struct.data_module.repository.gwt.qualified_rdate_name}.parse( #{transport_value} )"}
         when field.datetime? then Proc.new {|transport_value| "new java.util.Date( (long) #{transport_value} )"}
         when field.enumeration? then Proc.new {|transport_value| "#{field.gwt.java_component_type}.#{field.enumeration.textual_values? ? "valueOf( #{transport_value} )" : "values()[ #{field.nullable? ? "#{transport_value}.intValue()" : transport_value} ]"}"}
+        when field.integer? then Proc.new {|transport_value| "#{transport_value}.intValue()"}
         else nil
       end
 -%>


### PR DESCRIPTION
Domgen generates an uncompliable GWT DTO when architecture has a struct with an integer sequence field:
```
    data_module.struct(:UserDTO) do |s|
      s.integer(:PreviousAgencyId, :nullable => true, :collection_type => :sequence)
    end
```
This is due to the use of storing the value in a List<Double> field and not correctly converting it to integer in the getter.