### PR TITLE
Fixed bug when Struct has Integer Sequence field that are not nullable.

### DIFF
--- a/lib/domgen/gwt/helper.rb
+++ b/lib/domgen/gwt/helper.rb
@@ -40,10 +40,8 @@ module Domgen
             'double'
           elsif field.datetime? && field.nullable?
             'java.lang.Double'
-          elsif field.nullable? && field.integer?
+          elsif field.integer?
             'java.lang.Double'
-          elsif !field.nullable? && field.integer?
-            'int'
           elsif field.struct?
             field.gwt.java_component_type(:boundary)
           else


### PR DESCRIPTION
My previous fix #144 only worked when the field was nullable.

In this case:
```
    data_module.struct(:UserDTO) do |s|
      s.integer(:PreviousAgencyId, :collection_type => :sequence)
    end
```

Domgen generates an uncompliable GWT DTO, broken in both the create method and the getter.

Before the change, the field would be generated as an int[] with most of the sequence code expecting to work with an object array, probably as a hangover from the previous incarnation working with Lists.

Looking at the non-gwt struct generated server side, we use an List<Integer> for both the nullable and non nullable varients, so it made sense to use a Double[] for both on the GWT side. This design also seemed to be the simpliest solution.