### PR TITLE
Fix generators that were generating non-compiling code for exceptions with a nullable datetime

### DIFF
--- a/lib/domgen/action/templates/exception_json_encoder.java.erb
+++ b/lib/domgen/action/templates/exception_json_encoder.java.erb
@@ -38,7 +38,7 @@ public final class <%= exception.action.json_encoder_name %>
         when parameter.struct? then Proc.new {|value| "#{parameter.referenced_struct.action.qualified_json_encoder_name}.encode( #{value} )"}
         when (parameter.date? && parameter.nullable?) then Proc.new {|value, type| "null == #{value} ? javax.json.JsonValue.NULL : iris.rose.server.service.util.RDate.fromDate( (#{type}) #{value} ).toString()"}
         when parameter.date? then Proc.new {|value| "iris.rose.server.service.util.RDate.fromDate( #{value} ).toString()"}
-        when (parameter.datetime? && parameter.nullable?) then Proc.new {|value, type| "null == #{value} ? javax.json.JsonValue.NULL : javax.json.Json.createValue( ((#{type}) #{value}).getTime() )"}
+        when (parameter.datetime? && parameter.nullable?) then Proc.new {|value, type| "null == #{value} ? javax.json.JsonValue.NULL : javax.json.Json.createValue( #{value}.getTime() )"}
         when parameter.datetime? then Proc.new {|value| "javax.json.Json.createValue( #{value}.getTime() )"}
         when parameter.nullable? then Proc.new {|value| "null == #{value} ? javax.json.JsonValue.NULL : javax.json.Json.createValue( #{value} )"}
         else Proc.new{|value| value }

--- a/lib/domgen/imit/templates/client/exception.java.erb
+++ b/lib/domgen/imit/templates/client/exception.java.erb
@@ -3,7 +3,7 @@ package <%= to_package(exception.imit.qualified_name) %>;
 
 @java.lang.SuppressWarnings( { "UnusedDeclaration", "JavaDoc", "PMD.FormalParameterNamingConventions", "GwtInconsistentSerializableClass", "PMD.UnnecessaryConstructor" } )
 <% unless exception.ee.module_local? %>public <% end %><% if exception.abstract? %>abstract <% end %>class <%= exception.imit.name %> extends <%= exception.extends.nil? ? exception.java.standard_extends : exception.data_module.exception_by_name(exception.extends).imit.qualified_name %>
-  {
+{
 <% exception.declared_parameters.each do |parameter| -%>
   <%= annotated_type(parameter, :imit, :transport, :private => true, :final => true, :assume_generated => true) %> <%= parameter.name %>;
 <% end -%>
@@ -22,7 +22,7 @@ inherited_params_with_suffix = inherited_params + (inherited_params.size == 0 ? 
 
 constructor_access = exception.ee.module_local? ? '' : exception.abstract? ? 'protected ' : 'public '
 
-  if exception.imit.support_default_parameters? -%>
+if exception.imit.support_default_parameters? -%>
 
   <%= constructor_access %><%= exception.imit.name %>( <%= param_desc %> ) { this( <%= param_values_with_suffix %>null, null ); }
 
@@ -46,7 +46,7 @@ constructor_access = exception.ee.module_local? ? '' : exception.abstract? ? 'pr
   %>    this.<%= parameter.name %> = <%= parameter.name %>;
 <%   end -%>
 <% end -%>
-  }
+}
 
 <% exception.declared_parameters.each do |parameter| -%>
 

--- a/lib/domgen/imit/templates/client/exception.java.erb
+++ b/lib/domgen/imit/templates/client/exception.java.erb
@@ -3,7 +3,7 @@ package <%= to_package(exception.imit.qualified_name) %>;
 
 @java.lang.SuppressWarnings( { "UnusedDeclaration", "JavaDoc", "PMD.FormalParameterNamingConventions", "GwtInconsistentSerializableClass", "PMD.UnnecessaryConstructor" } )
 <% unless exception.ee.module_local? %>public <% end %><% if exception.abstract? %>abstract <% end %>class <%= exception.imit.name %> extends <%= exception.extends.nil? ? exception.java.standard_extends : exception.data_module.exception_by_name(exception.extends).imit.qualified_name %>
-{
+  {
 <% exception.declared_parameters.each do |parameter| -%>
   <%= annotated_type(parameter, :imit, :transport, :private => true, :final => true, :assume_generated => true) %> <%= parameter.name %>;
 <% end -%>
@@ -22,7 +22,7 @@ inherited_params_with_suffix = inherited_params + (inherited_params.size == 0 ? 
 
 constructor_access = exception.ee.module_local? ? '' : exception.abstract? ? 'protected ' : 'public '
 
-if exception.imit.support_default_parameters? -%>
+  if exception.imit.support_default_parameters? -%>
 
   <%= constructor_access %><%= exception.imit.name %>( <%= param_desc %> ) { this( <%= param_values_with_suffix %>null, null ); }
 
@@ -35,7 +35,7 @@ if exception.imit.support_default_parameters? -%>
   <%= constructor_access %><%= exception.imit.name %>( <% if exception.imit.support_default_parameters? -%><%= param_desc_with_suffix %>final String message, final Throwable cause<% else %><%= param_desc %><% end -%> )
   {
 <% if exception.imit.support_default_parameters? -%>
-    super( <%= inherited_params_with_suffix %>message, cause );
+  super( <%= inherited_params_with_suffix %>message, cause );
 <% end -%>
 <% exception.declared_parameters.each do |parameter|
   if :sequence == parameter.collection_type
@@ -62,8 +62,6 @@ when parameter.enumeration? then Proc.new {|transport_value| "#{parameter.gwt.ja
   end
 -%>
   return <% if parameter.nullable? -%>this.<%= parameter.name %> == null ? null : <% end -%>java.util.Arrays.stream( this.<%= parameter.name %> )<%= conversion_rule.nil? ? '' : ".map( e -> #{conversion_rule.call('e')} )" %>.collect( java.util.stream.Collectors.to<%= parameter.collection_type == :set ? 'Set' : 'List' %>() );
-<% elsif parameter.nullable? && parameter.datetime? -%>
-  return null == this.<%= parameter.name %> ? null : new java.util.Date( this.<%= parameter.name %>.longValue() );
 <% elsif parameter.datetime? -%>
   return  this.<%= parameter.name %>;
 <% elsif parameter.date? -%>
@@ -82,4 +80,4 @@ when parameter.enumeration? then Proc.new {|transport_value| "#{parameter.gwt.ja
   }
 <% end -%>
 <% end -%>
-}
+  }

--- a/lib/domgen/imit/templates/client/exception.java.erb
+++ b/lib/domgen/imit/templates/client/exception.java.erb
@@ -35,7 +35,7 @@ if exception.imit.support_default_parameters? -%>
   <%= constructor_access %><%= exception.imit.name %>( <% if exception.imit.support_default_parameters? -%><%= param_desc_with_suffix %>final String message, final Throwable cause<% else %><%= param_desc %><% end -%> )
   {
 <% if exception.imit.support_default_parameters? -%>
-  super( <%= inherited_params_with_suffix %>message, cause );
+    super( <%= inherited_params_with_suffix %>message, cause );
 <% end -%>
 <% exception.declared_parameters.each do |parameter|
   if :sequence == parameter.collection_type
@@ -46,7 +46,7 @@ if exception.imit.support_default_parameters? -%>
   %>    this.<%= parameter.name %> = <%= parameter.name %>;
 <%   end -%>
 <% end -%>
-}
+  }
 
 <% exception.declared_parameters.each do |parameter| -%>
 
@@ -80,4 +80,4 @@ when parameter.enumeration? then Proc.new {|transport_value| "#{parameter.gwt.ja
   }
 <% end -%>
 <% end -%>
-  }
+}


### PR DESCRIPTION
Karen found out that if you specify an exception with a nullable datetime then the exception on the client doesn't compile:
![image](https://github.com/user-attachments/assets/0b0f42ff-3edc-4778-bc05-7da740ba1e16)

And the encoder was also broken:
![image](https://github.com/user-attachments/assets/c56cc7e0-7fa1-4539-82e4-d5c04ba49067)

This change fixes the above issues