### PR TITLE
Add property to method.action facet to enable custom JSON encoder/decoder for method return value

### DIFF
--- a/lib/domgen/action/model.rb
+++ b/lib/domgen/action/model.rb
@@ -241,6 +241,8 @@ module Domgen
         @generate_serverside_action.nil? ? false : @generate_serverside_action
       end
 
+      attr_accessor :result_encoder
+
       attr_writer :retain_failed_message_duration
 
       def retain_failed_message_duration

--- a/lib/domgen/action/templates/service_actions.java.erb
+++ b/lib/domgen/action/templates/service_actions.java.erb
@@ -146,14 +146,18 @@ public class <%= service.action.service_actions_name %>
 
 <% end -%>
       @java.lang.SuppressWarnings( { "unchecked", "RedundantSuppression" } )
-      final var response = <% if method.return_value.struct?-%>
+      final var response = <% if !method.action.result_encoder.nil? -%>
+<%= method.action.result_encoder %>.encode( (<%= method.return_value.ejb.non_primitive_java_type(:boundary) %>) object );
+<% else -%>
+<% if method.return_value.struct?-%>
 <%= method.return_value.referenced_struct.action.qualified_json_encoder_name %>.encode( (<%= method.return_value.ejb.non_primitive_java_type(:boundary) %>) object );
 <% else -%>
  (<%= method.return_value.ejb.non_primitive_java_type(:boundary) %>) object;
 <% end -%>
+<% end -%>
 <% if method.return_value.collection? && !method.return_value.struct? -%>
       builder.add( "data", javax.json.Json.createArrayBuilder( response ) );
-<% elsif method.return_value.struct?-%>
+<% elsif method.return_value.struct? || !method.action.result_encoder.nil? -%>
       builder.add( "data", response );
 <% elsif method.return_value.boolean?-%>
       builder.add( "data", response ? javax.json.JsonValue.TRUE : javax.json.JsonValue.FALSE );


### PR DESCRIPTION
This was needed as EmwSynchronizationService.syncEmw returns a 'iris.syncrecord.server.data_type.SyncStatusDTO' which we don't generate a JSON encoder/decoder for.